### PR TITLE
QDockWidget support

### DIFF
--- a/iconpack/package.ini
+++ b/iconpack/package.ini
@@ -1,6 +1,6 @@
 Name = Dark
 Type = Iconpack
 Author = RandomHost
-Version = 0.8.0
+Version = 0.8.1
 Platforms =
 Description = "A dark icon theme to go with the Dark style."

--- a/package.ini
+++ b/package.ini
@@ -1,6 +1,6 @@
 Name = Dark
 Type = Style, Iconpack
 Author = random-host.com
-Version = 0.8.0
+Version = 0.8.1
 Platforms =
 Description = "A dark theme which looks surprisingly similar to another popular voice communication software. How did that happen?"

--- a/style/package.ini
+++ b/style/package.ini
@@ -1,6 +1,6 @@
 Name = Dark
 Type = Style
 Author = RandomHost
-Version = 0.8.0
+Version = 0.8.1
 Platforms =
 Description = "A dark theme which looks surprisingly similar to another popular voice communication software. How did that happen?"

--- a/style/styles/dark.qss
+++ b/style/styles/dark.qss
@@ -1232,6 +1232,13 @@ MsgDialog QTextBrowser {
     border-radius: 0;
 }
 
+/* Dock widgets */
+QDockWidget::title {
+    border: transparent;
+    background: #202225;
+    text-align: center;
+}
+
 /*
  * Attempt to fix the "Recipients" field in "New Offline Message" dialog
  *


### PR DESCRIPTION
This small update adds support for QDockWidgets used by third party plugins such as this:

https://github.com/svenpaulsen/ts3client-dockwidget-plugin