### PR TITLE
macOS specific fixes

### DIFF
--- a/style/styles/dark_mac.qss
+++ b/style/styles/dark_mac.qss
@@ -1,0 +1,12 @@
+/*
+ * Dark stylesheet for TeamSpeak 3 client
+ * Special file for macOS, loaded in addition to global improved.qss stylesheet
+ *
+ * Copyright (c) 2017 random-host.com
+ */
+
+/* macOS specific fixes */
+QComboBox,
+QRadioButton {
+    font-size: 12pt;
+}

--- a/style/styles/dark_mac.qss
+++ b/style/styles/dark_mac.qss
@@ -1,6 +1,6 @@
 /*
  * Dark stylesheet for TeamSpeak 3 client
- * Special file for macOS, loaded in addition to global improved.qss stylesheet
+ * Special file for macOS, loaded in addition to global dark.qss stylesheet
  *
  * Copyright (c) 2017 random-host.com
  */


### PR DESCRIPTION
This macOS specific fix resolves an issue with smaller font sizes in radiobuttons and comboboxes. 